### PR TITLE
Use Better Crafting's API to add compatibility

### DIFF
--- a/ItemBags/BetterCraftingInventoryProvider.cs
+++ b/ItemBags/BetterCraftingInventoryProvider.cs
@@ -1,0 +1,231 @@
+﻿using System.Collections.Generic;
+
+using ItemBags.Bags;
+
+using Leclair.Stardew.BetterCrafting;
+
+using Microsoft.Xna.Framework;
+
+using StardewModdingAPI.Events;
+using StardewModdingAPI.Utilities;
+
+using StardewValley;
+using StardewValley.Inventories;
+using StardewValley.Menus;
+using StardewValley.Network;
+
+namespace ItemBags
+{
+    public class BetterCraftingInventoryProvider : IInventoryProvider
+    {
+        // Split-screen stuff.
+        internal readonly static PerScreen<Dictionary<ItemBag, NetMutex>> BagMutexes = new(() => new());
+        internal readonly static PerScreen<Dictionary<ItemBag, ItemBagCraftingInventory>> BagInventories = new(() => new());
+
+        internal static bool IsValid(object thing)
+        {
+            return thing is ItemBag && thing is not BundleBag;
+        }
+
+
+        [EventPriority(EventPriority.Low)]
+        internal static void PopulateContainers(ISimplePopulateContainersEvent evt)
+        {
+            IBetterCrafting API = ItemBagsMod.ModInstance.BetterCraftingAPI;
+            if (API == null)
+                return;
+
+            // We use a temporary list to hold bag instances to
+            // avoid any weird concurrent modification stuff while
+            // iterating evt.Containers.
+            List<ItemBag> bags = new();
+
+            // Just to note, we use BagMutexes to keep track of the bags
+            // we're expecting to work with. We need to store them either
+            // way, so it lets us avoid having an extra HashSet.
+
+            // First, check the player's inventory for bags.
+            foreach (var item in Game1.player.Items)
+            {
+                if (item is ItemBag bag && IsValid(bag))
+                {
+                    bags.Add(bag);
+                    // No mutexes for the player's inventory.
+                    BagMutexes.Value[bag] = null;
+                }
+            }
+
+            // Iterate over the existing containers this menu is using.
+            foreach (var container in evt.Containers)
+            {
+                object thing = container.Item1;
+                GameLocation location = container.Item2;
+
+                // We need to use the API to get a provider for this container
+                // since it could be anything, in theory.
+                var provider = API.GetProvider(thing);
+                if (provider != null && provider.IsValid(thing, location, Game1.player))
+                {
+                    // If it's a valid container, then try to get a NetMutex for it.
+                    // If we can, then save the NetMutex so that anyone using the
+                    // bag will need to lock it to modify the bag. This will help
+                    // minimize de-sync issues on multiplayer.
+                    var mutex = provider.GetMutex(thing, location, Game1.player);
+                    if (mutex != null || !provider.IsMutexRequired(thing, location, Game1.player))
+                    {
+                        // If the provider has a valid mutex, or doesn't require
+                        // one, then we can check its items for any ItemBag instances
+                        // that we should be crafting with.
+                        var items = provider.GetItems(thing, location, Game1.player);
+                        if (items != null)
+                        {
+                            foreach (var item in items)
+                            {
+                                if (item is ItemBag bag && IsValid(bag))
+                                {
+                                    bags.Add(bag);
+                                    // Also store the mutex for later.
+                                    BagMutexes.Value[bag] = mutex;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Now add all the bags to the menu.
+            foreach (var item in bags)
+                evt.Containers.Add(new(item, null));
+        }
+
+        internal static void MenuClosing(IClickableMenu menu)
+        {
+            // Do one final sync of bag inventories. There may have been changes
+            // that we didn't catch with CleanInventory.
+            foreach (var inventory in BagInventories.Value.Values)
+                ResyncBag(inventory);
+
+            // Now clear them all.
+            BagInventories.Value.Clear();
+            BagMutexes.Value.Clear();
+        }
+
+        internal static void ResyncBag(ItemBagCraftingInventory inventory)
+        {
+            if (inventory != null)
+            {
+                // Close the inventory + clean the bag.
+                inventory.Close();
+
+                if (inventory.Source is OmniBag OB)
+                {
+                    foreach (var nested in OB.NestedBags)
+                        nested.Contents.RemoveAll(x => x == null || x.Stack <= 0);
+                }
+                else
+                {
+                    inventory.Source.Contents.RemoveAll(x => x == null || x.Stack <= 0);
+                }
+
+                // Re-sync the bag.
+                inventory.Source.Resync();
+            }
+        }
+
+
+        private static ItemBagCraftingInventory GetBagInventory(object item, bool createIfMissing = true)
+        {
+            // Make sure the item is a bag, and that we have a mutex (or null) for it.
+            if (item is not ItemBag bag || !BagMutexes.Value.ContainsKey(bag))
+                return null;
+
+            if (BagInventories.Value.TryGetValue(bag, out ItemBagCraftingInventory inventory))
+                return inventory;
+
+            if (!createIfMissing)
+                return null;
+
+            inventory = new ItemBagCraftingInventory(bag);
+            BagInventories.Value[bag] = inventory;
+            return inventory;
+        }
+
+        public bool CanExtractItems(object obj, GameLocation location, Farmer who)
+        {
+            return IsValid(obj, location, who);
+        }
+
+        public bool CanInsertItems(object obj, GameLocation location, Farmer who)
+        {
+            return false;
+        }
+
+        public void CleanInventory(object obj, GameLocation location, Farmer who)
+        {
+            // This can be called after a crafting operation has modified an
+            // inventory, and if so, is called before the mutex is released, so
+            // this is probably a good place to re-sync the contents of a bag.
+
+            // (Specifically, Better Crafting calls this currently if any Items
+            // were set to null, but that is an implementation detail that may
+            // change in the future.)
+
+            var inventory = GetBagInventory(obj, createIfMissing: false);
+            if (inventory != null)
+            {
+                ResyncBag(inventory);
+
+                // Remove this inventory from the cache so it is recreated
+                // for the next use.
+                BagInventories.Value.Remove(inventory.Source);
+            }
+        }
+
+        public int GetActualCapacity(object obj, GameLocation location, Farmer who)
+        {
+            return GetBagInventory(obj)?.CountItemStacks() ?? 0;
+        }
+
+        public IInventory GetInventory(object obj, GameLocation location, Farmer who)
+        {
+            /// Cannot return the inventory because Better Crafting may
+            /// access methods that are only stubs throwing exceptions.
+            /// Notably: <see cref="IInventory.LastTickSlotChanged"/>
+            return null;
+        }
+
+        public IList<Item> GetItems(object obj, GameLocation location, Farmer who)
+        {
+            return GetBagInventory(obj);
+        }
+
+        public Rectangle? GetMultiTileRegion(object obj, GameLocation location, Farmer who)
+        {
+            return null;
+        }
+
+        public NetMutex GetMutex(object obj, GameLocation location, Farmer who)
+        {
+            if (obj is ItemBag bag && BagMutexes.Value.ContainsKey(bag))
+                return BagMutexes.Value[bag];
+            return null;
+        }
+
+        public bool IsMutexRequired(object obj, GameLocation location, Farmer who)
+        {
+            if (obj is ItemBag bag && BagMutexes.Value.ContainsKey(bag))
+                return BagMutexes.Value[bag] != null;
+            return false;
+        }
+
+        public Vector2? GetTilePosition(object obj, GameLocation location, Farmer who)
+        {
+            return null;
+        }
+
+        public bool IsValid(object obj, GameLocation location, Farmer who)
+        {
+            return obj is ItemBag bag && IsValid(bag) && BagMutexes.Value.ContainsKey(bag);
+        }
+    }
+}

--- a/ItemBags/CraftingHandler.cs
+++ b/ItemBags/CraftingHandler.cs
@@ -1,17 +1,17 @@
-﻿using ItemBags.Bags;
-using Microsoft.Xna.Framework;
-using StardewModdingAPI;
-using StardewModdingAPI.Events;
-using StardewValley;
-using StardewValley.Inventories;
-using StardewValley.Menus;
-using StardewValley.Objects;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using ItemBags.Bags;
+
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
+
+using StardewValley;
+using StardewValley.Inventories;
+using StardewValley.Menus;
+
 using Object = StardewValley.Object;
 
 namespace ItemBags
@@ -88,8 +88,8 @@ namespace ItemBags
             bool IsBetterCraftingInstalled = Helper.ModRegistry.IsLoaded(BetterCraftingUniqueId);
             if (IsBetterCraftingInstalled)
             {
-                ItemBagsMod.ModInstance.Monitor.Log($"'Better Crafting' mod ({BetterCraftingUniqueId}) detected. " +
-                    $"You will not be able to craft using items inside of bags.", LogLevel.Info);
+                //ItemBagsMod.ModInstance.Monitor.Log($"'Better Crafting' mod ({BetterCraftingUniqueId}) detected. " +
+                //    $"You will not be able to craft using items inside of bags.", LogLevel.Info);
             }
             else
             {
@@ -256,7 +256,7 @@ namespace ItemBags
 
         private static bool IsCompatibleCraftingPage(IClickableMenu Menu)
         {
-            return Menu is CraftingPage || 
+            return Menu is CraftingPage ||
                 (Menu?.GetType().FullName == "CookingSkill.NewCraftingPage" && IsCookingSkillModCompatible); // CookingSkill.NewCraftingPage is a menu defined in the "Cooking Skill" mod
         }
     }
@@ -338,8 +338,8 @@ namespace ItemBags
             $"This object is only intended to be used by crafting pages, and only supports removing items.";
 
         public Item this[int index]
-        { 
-            get => Items[index]; 
+        {
+            get => Items[index];
             set
             {
                 //  As of game version 1.6.3.24087, this is the decompiled logic for StardewValley.Item.ConsumeStack(int amount):
@@ -396,7 +396,7 @@ namespace ItemBags
             else
                 return results;
         }
-            
+
         public bool HasAny() => Items.Any();
         public bool HasEmptySlots() => Count > CountItemStacks();
         public int IndexOf(Item item) => Items.IndexOf(item);

--- a/ItemBags/IBetterCraftingAPI.cs
+++ b/ItemBags/IBetterCraftingAPI.cs
@@ -135,6 +135,65 @@ public interface IInventoryProvider
 
 }
 
+/// <summary>
+/// This is an extension of <see cref="IInventoryProvider"/> that allows you
+/// to implement custom logic that runs before and after an inventory is
+/// used for write operations. You can use this to perform locks or to
+/// synchronize an object.
+/// </summary>
+public interface IEventedInventoryProvider : IInventoryProvider
+{
+
+    /// <summary>
+    /// The callback method you call when we have either obtained exclusive
+    /// access to the inventory, or doing so has failed for some reason.
+    /// </summary>
+    /// <param name="success">Whether or not we have obtained exclusive access</param>
+    delegate void StartExclusiveCallback(bool success);
+
+    /// <summary>
+    /// This is called when we need exclusive access to an inventory to perform
+    /// write operations. You are expected to either return a boolean, or
+    /// return <c>null</c> and then call <paramref name="callback"/>
+    /// when any logic necessary to obtain write access to the inventory is
+    /// completed, and may call it immediately.
+    ///
+    /// If this method returns <c>null</c>, then you MUST call onComplete even
+    /// if the object cannot be obtained for write access.
+    ///
+    /// If you are using native NetMutex to control exclusive access, you do
+    /// not need to use these methods and can just use the standard
+    /// <see cref="IInventoryProvider.GetMutex(object, GameLocation?, Farmer?)"/>
+    /// and <see cref="IInventoryProvider.IsMutexRequired(object, GameLocation?, Farmer?)"/>
+    /// methods for exclusive access.
+    /// 
+    /// If you do not call onComplete within 5 seconds, the operation will
+    /// time out and an error will be logged / shown to the user.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    /// <param name="callback">A callback to call when the object has been
+    /// obtained for write access. Call this with <c>true</c> if the object
+    /// was obtained successfully, or <c>false</c> if it could not be
+    /// obtained successfully.</param>
+    /// <returns>Whether there was an immediate success (<c>true</c>), an
+    /// immediate failure (<c>false</c>), or we should expect the callback
+    /// to be called (<c>null</c>).</returns>
+    bool? StartExclusive(object obj, GameLocation? location, Farmer? who, StartExclusiveCallback callback);
+
+    /// <summary>
+    /// This is called whenever we are done using an inventory exclusively,
+    /// and can be used to perform any necessary cleanup logic and to release
+    /// any locks.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    void EndExclusive(object obj, GameLocation? location, Farmer? who);
+
+}
+
 
 /// <summary>
 /// A simplified interface for the PopulateContainers event that allows

--- a/ItemBags/IBetterCraftingAPI.cs
+++ b/ItemBags/IBetterCraftingAPI.cs
@@ -1,0 +1,206 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.Xna.Framework;
+
+using StardewValley;
+using StardewValley.Inventories;
+using StardewValley.Menus;
+using StardewValley.Network;
+
+namespace Leclair.Stardew.BetterCrafting;
+
+/// <summary>
+/// An <c>IInventoryProvider</c> is used by Better Crafting to discover and
+/// interact with various item storages in the game.
+/// </summary>
+public interface IInventoryProvider
+{
+
+    /// <summary>
+    /// Check to see if this object is valid for inventory operations.
+    ///
+    /// If location is null, it should not be considered when determining
+    /// the validity of the object.
+    /// 
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    /// <returns>whether or not the object is valid</returns>
+    bool IsValid(object obj, GameLocation? location, Farmer? who);
+
+    /// <summary>
+    /// Check to see if items can be inserted into this object.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    /// <returns></returns>
+    bool CanInsertItems(object obj, GameLocation? location, Farmer? who);
+
+    /// <summary>
+    /// Check to see if items can be extracted from this object.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    /// <returns></returns>
+    bool CanExtractItems(object obj, GameLocation? location, Farmer? who);
+
+    /// <summary>
+    /// For objects larger than a single tile on the map, return the rectangle representing
+    /// the object. For single tile objects, return null.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    /// <returns></returns>
+    Rectangle? GetMultiTileRegion(object obj, GameLocation? location, Farmer? who);
+
+    /// <summary>
+    /// Return the real position of the object. If the object has no position, returns null.
+    /// For multi-tile objects, this should return the "main" object if there is one. 
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    Vector2? GetTilePosition(object obj, GameLocation? location, Farmer? who);
+
+    /// <summary>
+    /// Get the NetMutex that locks the object for multiplayer synchronization. This method must
+    /// return a mutex. If null is returned, the object will be skipped.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    NetMutex? GetMutex(object obj, GameLocation? location, Farmer? who);
+
+    /// <summary>
+    /// Whether or not a mutex is required for interacting with this object's inventory.
+    /// You should always use a mutex to ensure items are handled safely with multiplayer,
+    /// but in case you're doing something exceptional and Better Crafting should not
+    /// worry about locking, you can explicitly disable mutex handling.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    bool IsMutexRequired(object obj, GameLocation? location, Farmer? who) => true;
+
+    /// <summary>
+    /// Get a list of items in the object's inventory, for modification or viewing. Assume that
+    /// anything using this list will use GetMutex() to lock the inventory before modifying.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    IList<Item?>? GetItems(object obj, GameLocation? location, Farmer? who);
+
+    /// <summary>
+    /// Get a vanilla <c>IInventory</c> for an object, if one exists.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the object, or null if no player is involved</param>
+    /// <returns></returns>
+    IInventory? GetInventory(object obj, GameLocation? location, Farmer? who);
+
+    /// <summary>
+    /// Check to see if a specific item is allowed to be stored in the object's inventory.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    /// <param name="item">the item we're checking</param>
+    bool IsItemValid(object obj, GameLocation? location, Farmer? who, Item item) => true;
+
+    /// <summary>
+    /// Clean the inventory of the object. This is for removing null entries, organizing, etc.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    void CleanInventory(object obj, GameLocation? location, Farmer? who);
+
+    /// <summary>
+    /// Get the actual inventory capacity of the object's inventory. New items may be added to the
+    /// GetItems() list up until this count.
+    /// </summary>
+    /// <param name="obj">the object</param>
+    /// <param name="location">the map where the object is</param>
+    /// <param name="who">the player accessing the inventory, or null if no player is involved</param>
+    int GetActualCapacity(object obj, GameLocation? location, Farmer? who);
+
+}
+
+
+/// <summary>
+/// A simplified interface for the PopulateContainers event that allows
+/// you to remove the IBetterCraftingMenu interface.
+/// </summary>
+public interface ISimplePopulateContainersEvent
+{
+    /// <summary>
+    /// A list of all the containers this menu should draw items from.
+    /// </summary>
+    IList<Tuple<object, GameLocation?>> Containers { get; }
+
+    /// <summary>
+    /// Set this to true to prevent Better Crafting from running its
+    /// own container discovery logic, if you so desire.
+    /// </summary>
+    bool DisableDiscovery { get; set; }
+}
+
+
+public interface IBetterCrafting
+{
+
+    #region Events
+
+    /// <summary>
+    /// This event is fired whenever a new Better Crafting menu is opened,
+    /// allowing other mods to manipulate the list of containers. This
+    /// version of the event doesn't include a reference to the menu, which
+    /// makes it possible to reduce the amount of the API file you're
+    /// using by quite a bit.
+    /// </summary>
+    event Action<ISimplePopulateContainersEvent>? MenuSimplePopulateContainers;
+
+    /// <summary>
+    /// This event is fired whenever a Better Crafting menu is closed.
+    /// </summary>
+    event Action<IClickableMenu>? MenuClosing;
+
+    #endregion
+
+    #region Inventories
+
+    /// <summary>
+    /// Register an inventory provider with Better Crafting. Inventory
+    /// providers are used for interfacing with chests and other objects
+    /// in the world that contain items.
+    /// </summary>
+    /// <param name="type"></param>
+    /// <param name="provider"></param>
+    void RegisterInventoryProvider(Type type, IInventoryProvider provider);
+
+    /// <summary>
+    /// Unregister an inventory provider.
+    /// </summary>
+    /// <param name="type"></param>
+    void UnregisterInventoryProvider(Type type);
+
+    /// <summary>
+    /// Get an inventory provider for the provided thing. If there are no
+    /// inventory providers capable of handling the thing, returns
+    /// <c>null</c> instead.
+    /// </summary>
+    /// <param name="thing">The instance to get an inventory provider for.</param>
+    IInventoryProvider? GetProvider(object thing);
+
+    #endregion
+
+}

--- a/ItemBags/ItemBagsMod.cs
+++ b/ItemBags/ItemBagsMod.cs
@@ -1,23 +1,23 @@
-﻿using ItemBags.Bags;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using ItemBags.Bags;
 using ItemBags.Community_Center;
 using ItemBags.Helpers;
 using ItemBags.Menus;
 using ItemBags.Persistence;
+
+using Leclair.Stardew.BetterCrafting;
+
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
+
 using StardewValley;
 using StardewValley.Menus;
-using StardewValley.Tools;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.Serialization;
-using System.Xml.Serialization;
+
 using static ItemBags.Persistence.BagSizeConfig;
-using Object = StardewValley.Object;
 
 namespace ItemBags
 {
@@ -35,6 +35,7 @@ namespace ItemBags
         public const string SpaceCoreUniqueId = "spacechase0.SpaceCore";
         public const string SaveAnywhereUniqueId = "Omegasis.SaveAnywhere";
         public const string EntoaroxFrameworkUniqueId = "Entoarox.EntoaroxFramework";
+        public const string BetterCraftingUniqueId = "leclair.bettercrafting";
 
         internal static ItemBagsMod ModInstance { get; private set; }
         public static IMonitor Logger => ModInstance?.Monitor;
@@ -58,6 +59,8 @@ namespace ItemBags
         public static UserConfig UserConfig { get; internal set; }
         private const string ModdedItemsFilename = "modded_items.json";
         public static ModdedItems ModdedItems { get; private set; }
+
+        internal IBetterCrafting BetterCraftingAPI;
 
         internal static Dictionary<ModdedBag, BagType> TemporaryModdedBagTypes { get; private set; }
 
@@ -111,6 +114,25 @@ namespace ItemBags
                     catch (Exception ex)
                     {
                         Monitor.Log(string.Format("Failed to bind to Save Anywhere's Mod API. Your game may crash while saving with Save Anywhere! Error: {0}", ex.Message), LogLevel.Warn);
+                    }
+                }
+
+                // Add compatibility with Better Crafting
+                if (Helper.ModRegistry.IsLoaded(BetterCraftingUniqueId) && !Helper.ModRegistry.Get(BetterCraftingUniqueId).Manifest.Version.IsOlderThan("2.12.0"))
+                {
+                    try
+                    {
+                        BetterCraftingAPI = Helper.ModRegistry.GetApi<IBetterCrafting>(BetterCraftingUniqueId);
+                        if (BetterCraftingAPI != null)
+                        {
+                            BetterCraftingAPI.RegisterInventoryProvider(typeof(ItemBag), new BetterCraftingInventoryProvider());
+                            BetterCraftingAPI.MenuSimplePopulateContainers += BetterCraftingInventoryProvider.PopulateContainers;
+                            BetterCraftingAPI.MenuClosing += BetterCraftingInventoryProvider.MenuClosing;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Monitor.Log(string.Format("Failed to bind to Better Crafting's Mod API. You will not be able to craft using items inside of bags. Error: {0}", ex.Message), LogLevel.Warn);
                     }
                 }
 

--- a/ItemBags/manifest.json
+++ b/ItemBags/manifest.json
@@ -9,8 +9,12 @@
   "UpdateKeys": [ "Nexus:5382" ],
   "Dependencies": [
     {
-      "UniqueID": "spacechase0.JsonAssets",
-      "IsRequired": false
+        "UniqueID": "spacechase0.JsonAssets",
+        "IsRequired": false
+    },
+    {
+        "UniqueID": "leclair.bettercrafting",
+        "IsRequired": false
     },
     {
       "UniqueID": "spacechase0.SpaceCore",


### PR DESCRIPTION
Hello there!

This adds support for Better Crafting by using Better Crafting's API to teach it how to handle Item Bags, and tell it about any relevant Item Bags in the player's inventory + existing inventories. Once I saw you had implemented a basic IInventory, I wanted to do this.

Please let me know what you think. I'd like to get support for Item Bags + Better Crafting since a lot of users have asked for it over time, and I think it'd be best implemented with something like this.

You might want to clean it up a bit, but I based the logic on what you're doing for the vanilla crafting menu.