### PR TITLE
Implement support for Better Game Menu

### DIFF
--- a/ItemBags/AutofillHandler.cs
+++ b/ItemBags/AutofillHandler.cs
@@ -167,7 +167,7 @@ namespace ItemBags
                         //  (characterDialogue is null when attempting to eat a food item)
                         CanAutofill = ReflectionDialogue != null && ReflectionDialogue.GetValue() == null;
                     }
-                    else if (Game1.activeClickableMenu is GameMenu GameMenu && GameMenu.currentTab != GameMenu.craftingTab)
+                    else if (ItemBagsMod.IsGameMenu(Game1.activeClickableMenu) && ItemBagsMod.GetGameMenuPage(Game1.activeClickableMenu) is not CraftingPage)
                     {
                         //  Ignore InventoryChanged events that are due to an inventory item being dragged/dropped to/from the cursor
                         bool DidCursorSlotItemChange = Game1.player.CursorSlotItem != PreviousInventoryCursorSlotItem;

--- a/ItemBags/IBetterGameMenuAPI.cs
+++ b/ItemBags/IBetterGameMenuAPI.cs
@@ -1,0 +1,23 @@
+﻿#nullable enable
+
+using StardewValley.Menus;
+
+namespace Leclair.Stardew.BetterGameMenu;
+
+
+public interface IBetterGameMenuApi
+{
+
+    #region Menu Class Access
+
+    /// <summary>
+    /// Get the current page of the provided Better Game Menu instance. If the
+    /// provided menu is not a Better Game Menu, or a page is not ready, then
+    /// return <c>null</c> instead.
+    /// </summary>
+    /// <param name="menu">The menu to get the page from.</param>
+    IClickableMenu? GetCurrentPage(IClickableMenu menu);
+
+    #endregion
+
+}

--- a/ItemBags/InputHandler.cs
+++ b/ItemBags/InputHandler.cs
@@ -66,7 +66,7 @@ namespace ItemBags
                 //  Swaps the current CursorSlotItem with the inventory item at index=QueueCursorSlotIndex
                 if (QueuePlaceCursorSlotItem && QueueCursorSlotIndex.HasValue)
                 {
-                    if (Game1.activeClickableMenu is GameMenu GM && GM.currentTab == GameMenu.inventoryTab)
+                    if (ItemBagsMod.GetGameMenuPage(Game1.activeClickableMenu) is InventoryPage)
                     {
                         Item Temp = Game1.player.Items[QueueCursorSlotIndex.Value];
                         Game1.player.Items[QueueCursorSlotIndex.Value] = Game1.player.CursorSlotItem;
@@ -166,9 +166,8 @@ namespace ItemBags
                         catch (Exception ex) { Monitor.Log(string.Format("Unhandled error while handling Gamepad button pressed: {0}\n\n{1}", ex.Message, ex.ToString()), LogLevel.Error); }
                     }
                 }
-                else if (Game1.activeClickableMenu != null && Game1.activeClickableMenu is GameMenu GM && GM.currentTab == GameMenu.inventoryTab)
+                else if (ItemBagsMod.GetGameMenuPage(Game1.activeClickableMenu) is InventoryPage InvPage)
                 {
-                    InventoryPage InvPage = GM.pages.First(x => x is InventoryPage) as InventoryPage;
                     InventoryMenu InvMenu = InvPage.inventory;
 
                     int ClickedItemIndex = InvMenu.getInventoryPositionOfClick(CursorPos.X, CursorPos.Y);


### PR DESCRIPTION
Hello!

[Better Game Menu](https://github.com/KhloeLeclair/StardewMods/releases/tag/BetterGameMenu-0.5.5) is a new mod I'm going to be releasing at the end of March that replaces `GameMenu` with a replacement that:

1. Is considerably more efficient by virtue of only creating page instances when the pages are actually accessed.
2. Has a robust API to let other mods work with the game menu, making it easy to register new tabs, override existing tabs, and respond to events involving the menu.

I realize this has the potential to break a lot of things, so I'm going to be submitting PRs to various mods that interact with GameMenu to implement support for BetterGameMenu. This is such a PR.

---

With Item Bags, the main compatibility issue is that you do a lot of checks for `GameMenu` to 1) check that it's open and 2) get the current page. This is the same issue most mods have.

To address that, I've introduced helper methods that support both `GameMenu` and Better Game Menu through its API.

I also replaced several checks for a specific tab index in the game menu with checking that the current page is an instance of the expected class. This pattern is more convenient for supporting both GM and BGM, since BGM doesn't use integer keys for tabs, and most robust in the event of another mod messing with the menu and replacing a page with something you don't expect or support.

I hope this is helpful. Please contact me if you have any questions!